### PR TITLE
-fix: Number input parsing

### DIFF
--- a/Helpers/System/NumberHelper.cs
+++ b/Helpers/System/NumberHelper.cs
@@ -66,7 +66,7 @@ namespace VieweD.Helpers.System
             }
             else
             {
-                result = int.TryParse(field, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out res);
+                result = int.TryParse(field, NumberStyles.Integer, CultureInfo.InvariantCulture, out res);
             }
 
             // Re-apply negative sign if required
@@ -115,7 +115,7 @@ namespace VieweD.Helpers.System
             else
             {
                 // Handle it as a regular long
-                result = long.TryParse(field, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out res);
+                result = long.TryParse(field, NumberStyles.Integer, CultureInfo.InvariantCulture, out res);
             }
 
             // Re-apply negative sign if required
@@ -154,7 +154,7 @@ namespace VieweD.Helpers.System
                     NumberStyles.HexNumber, CultureInfo.InvariantCulture, out res);
             }
 
-            return ulong.TryParse(field, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out res);
+            return ulong.TryParse(field, NumberStyles.Integer, CultureInfo.InvariantCulture, out res);
         }
     }
 }

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("ZeromusXYZ")]
 [assembly: AssemblyProduct("VieweD")]
-[assembly: AssemblyCopyright("Copyright © 2020-2022, No Rights Reserved")]
+[assembly: AssemblyCopyright("Copyright © 2020-2023, No Rights Reserved")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -33,6 +33,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.0.2")]
-[assembly: AssemblyFileVersion("0.9.0.2")]
+[assembly: AssemblyVersion("0.9.1.0")]
+[assembly: AssemblyFileVersion("0.9.1.0")]
 [assembly: Packer]


### PR DESCRIPTION
Fixes issue #1 where all number were parsed as being hex, even without the prefix/suffix for them.